### PR TITLE
refactor: TodoItem 마다 각각 DetailModal 렌더하던 구조 수정

### DIFF
--- a/src/components/TodoKanban/TodoItem/TodoItem.tsx
+++ b/src/components/TodoKanban/TodoItem/TodoItem.tsx
@@ -43,7 +43,6 @@ const TodoItem: React.FC<ITodoProps> = ({ todo, openDetail, onDragStart, onDragE
           <FontAwesomeIcon icon={faPen} />
         </EditIcon>
       </IconWrap>
-      {/* <DetailModal visible={detailVisible} onClose={closeDetail} item={todo} /> */}
     </TodoItemLayout>
   );
 };

--- a/src/components/TodoKanban/TodoItem/TodoItem.tsx
+++ b/src/components/TodoKanban/TodoItem/TodoItem.tsx
@@ -5,20 +5,18 @@ import styled from 'styled-components';
 import { ITodo } from 'type';
 import { dateToString } from 'utils/commons';
 import { useTodoAndDispatchContext } from 'context/TodoContext';
-import useModal from 'hooks/useModal';
-import DetailModal from 'components/common/Modal/DetailModal';
 
 interface ITodoProps {
   todo: ITodo;
+  openDetail: (item: ITodo) => void;
   onDragStart: (e: React.DragEvent<HTMLDivElement>) => void;
   onDragEnter: (e: React.DragEvent<HTMLDivElement>) => void;
   onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
 }
 
-const TodoItem: React.FC<ITodoProps> = ({ todo, onDragStart, onDragEnter, onDragOver }) => {
+const TodoItem: React.FC<ITodoProps> = ({ todo, openDetail, onDragStart, onDragEnter, onDragOver }) => {
   const { dispatch } = useTodoAndDispatchContext();
   const { task, priority, deadLine, status } = todo;
-  const [detailVisible, openDetail, closeDetail] = useModal(false);
 
   const handleDeleteTodo = () => {
     dispatch({ type: 'REMOVE', id: todo.id });
@@ -41,11 +39,11 @@ const TodoItem: React.FC<ITodoProps> = ({ todo, onDragStart, onDragEnter, onDrag
         <DeleteIcon onClick={handleDeleteTodo}>
           <FontAwesomeIcon icon={faTrashAlt} />
         </DeleteIcon>
-        <EditIcon>
-          <FontAwesomeIcon icon={faPen} onClick={openDetail} />
+        <EditIcon onClick={() => openDetail(todo)}>
+          <FontAwesomeIcon icon={faPen} />
         </EditIcon>
       </IconWrap>
-      <DetailModal visible={detailVisible} onClose={closeDetail} item={todo} />
+      {/* <DetailModal visible={detailVisible} onClose={closeDetail} item={todo} /> */}
     </TodoItemLayout>
   );
 };

--- a/src/components/TodoKanban/TodoKanBan.tsx
+++ b/src/components/TodoKanban/TodoKanBan.tsx
@@ -1,18 +1,38 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Status } from 'type';
+import { Status, ITodo, Priority } from 'type';
 import { useLoadStorage, useSaveStorage } from 'hooks/useStorage';
 import TodoList from './TodoList/TodoList';
+import useModal from 'hooks/useModal';
+import DetailModal from 'components/common/Modal/DetailModal';
+
+const defaultModal: ITodo = {
+  id: 1,
+  task: '',
+  priority: Priority.LOW,
+  status: Status.NOT_STARTED,
+  deadLine: new Date(),
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
 
 const TodoKanBan: React.FC = () => {
   useLoadStorage();
   useSaveStorage();
+  const [modalVisible, openModal, closeModal] = useModal(false);
+  const [detailTodo, setDetailTodo] = useState<ITodo | null>(null);
+
+  const openDetail = (item: ITodo) => {
+    setDetailTodo(item);
+    openModal();
+  };
 
   return (
     <TodoKanBanContainer>
-      <TodoList status={Status.NOT_STARTED} />
-      <TodoList status={Status.IN_PROGRESS} />
-      <TodoList status={Status.FINISHED} />
+      <TodoList status={Status.NOT_STARTED} openDetail={openDetail} />
+      <TodoList status={Status.IN_PROGRESS} openDetail={openDetail} />
+      <TodoList status={Status.FINISHED} openDetail={openModal} />
+      <DetailModal visible={modalVisible} onClose={closeModal} item={detailTodo || defaultModal} />
     </TodoKanBanContainer>
   );
 };

--- a/src/components/TodoKanban/TodoKanBan.tsx
+++ b/src/components/TodoKanban/TodoKanBan.tsx
@@ -7,7 +7,7 @@ import useModal from 'hooks/useModal';
 import DetailModal from 'components/common/Modal/DetailModal';
 
 const defaultModal: ITodo = {
-  id: 1,
+  id: 0,
   task: '',
   priority: Priority.LOW,
   status: Status.NOT_STARTED,

--- a/src/components/TodoKanban/TodoList/TodoList.tsx
+++ b/src/components/TodoKanban/TodoList/TodoList.tsx
@@ -1,14 +1,15 @@
 import React, { useRef } from 'react';
 import styled from 'styled-components';
 import { useTodoAndDispatchContext } from 'context/TodoContext';
-import { Status } from 'type';
+import { Status, ITodo } from 'type';
 import TodoItem from '../TodoItem/TodoItem';
 
 interface ITodosProps {
   status: Status;
+  openDetail: (item: ITodo) => void;
 }
 
-const TodoList: React.FC<ITodosProps> = ({ status }) => {
+const TodoList: React.FC<ITodosProps> = ({ status, openDetail }) => {
   const {
     modifiedTodos,
     todosWithFilterAndSort: { todos },
@@ -49,6 +50,7 @@ const TodoList: React.FC<ITodosProps> = ({ status }) => {
           <TodoBlock key={todo.id}>
             <TodoItem
               todo={todo}
+              openDetail={openDetail}
               onDragStart={(e) => handleDragStart(e, index)}
               onDragEnter={(e) => handleDragEnter(e, index)}
               onDragOver={(e) => e.preventDefault()}

--- a/src/components/common/Modal/DetailModal/DetailModal.tsx
+++ b/src/components/common/Modal/DetailModal/DetailModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { ITodo, IEditTodo, Priority, Status } from 'type';
 import Modal, { IModal } from '../Modal';
@@ -18,6 +18,9 @@ const DetailModal: React.FC<IDetailModal> = ({ item, visible, onClose }) => {
   const { dispatch } = useTodoAndDispatchContext();
   const [editTodo, setEditTodo] = useState<IEditTodo>(item);
   const { task, priority, status, deadLine } = editTodo;
+  useEffect(() => {
+    setEditTodo(item);
+  }, [item]);
 
   const handleTodo = (key: string, value: string | Priority | Status | Date | null) => {
     setEditTodo((prev) => ({

--- a/src/components/common/Modal/Form/ModalRadioForm/ModalRadioForm.tsx
+++ b/src/components/common/Modal/Form/ModalRadioForm/ModalRadioForm.tsx
@@ -14,8 +14,8 @@ interface IModalRadioForm {
 const ModalRadioForm: React.FC<IModalRadioForm> = ({ optionKey, headerText, isNullOption = false, activeOption, optionList, handleValue }) => {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.persist();
-    const { id } = e.target;
-    id === 'null' ? handleValue(optionKey, null) : handleValue(optionKey, id);
+    const { value } = e.target;
+    value === 'null' ? handleValue(optionKey, null) : handleValue(optionKey, value);
   };
   return (
     <Wrapper>

--- a/src/components/common/Modal/Form/ModalRadioForm/RadioItem.tsx
+++ b/src/components/common/Modal/Form/ModalRadioForm/RadioItem.tsx
@@ -30,7 +30,7 @@ const RadioItem: React.FC<IRadioItem> = ({ name, id, isActive, onChange }) => {
 
   return (
     <SelectorItem>
-      <RadioButtonItem type='radio' name={name} id={id} checked={isActive} onChange={onChange} />
+      <RadioButtonItem type='radio' name={name} value={id} checked={isActive} onChange={onChange} />
       <LabelText isActive={isActive}>{labelText(id)}</LabelText>
     </SelectorItem>
   );

--- a/src/components/common/Modal/SortModal/SortModal.tsx
+++ b/src/components/common/Modal/SortModal/SortModal.tsx
@@ -15,15 +15,15 @@ export interface ISortModal extends IModal {
   sortOptions?: ISortOption;
 }
 
-const mockSortOption: ISortOption = {
-  sortBy: 'updatedAt',
+const defaultSortOption: ISortOption = {
+  sortBy: null,
   order: 'DESC',
 };
 
 const sortByOptionList: string[] = ['deadLine', 'updatedAt', 'priority']; //priority 옵션 우선순위는 추후 추가
 const orderOptionList: ('DESC' | 'ASC')[] = ['DESC', 'ASC'];
 
-const SortModal: React.FC<ISortModal> = ({ sortOptions = mockSortOption, visible, onClose }) => {
+const SortModal: React.FC<ISortModal> = ({ sortOptions = defaultSortOption, visible, onClose }) => {
   const [sort, setSort] = useState<ISortOption>(sortOptions);
   const { dispatch } = useTodoAndDispatchContext();
   const handleSort = (key: string, option: string | null) => {


### PR DESCRIPTION
- 기존 TodoItem에 있던 DetailModal 제거
- TodoKaban 에 DetailModal  로직 이동
- TodoItem의  editButton 클릭시 해당 TodoItem의 Props으로 DeatilModal 내부 state로 업데이트 하는 로직 추가
- refresh했을때 뜨던  id중복 warning 수정